### PR TITLE
Convert null values to JsonNull

### DIFF
--- a/lib/src/main/java/com/segment/analytics/kotlin/destinations/appsflyer/AppsflyerDestination.kt
+++ b/lib/src/main/java/com/segment/analytics/kotlin/destinations/appsflyer/AppsflyerDestination.kt
@@ -180,6 +180,7 @@ class AppsFlyerDestination(
 
         private fun convertToPrimitive(value: Any?): JsonElement {
             return when (value) {
+                null -> JsonNull
                 is Boolean -> JsonPrimitive(value)
                 is Number -> JsonPrimitive(value)
                 is String -> JsonPrimitive(value)


### PR DESCRIPTION
If we don't handle null values explicitly, they end up in the `else` case and are converted to strings, which ends up with null values being sent as "null" strings.